### PR TITLE
Address MacOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ sudo apt-get install pandoc
 sudo dnf install pandoc
 ```
 
+#### MacOS:
+```shell
+brew install pandoc
+```
+
 ### downloading psg
 
 It's as simple as can be.

--- a/psg.py
+++ b/psg.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import http.server
 import os


### PR DESCRIPTION
* Change shebang to `/usr/bin/env` which also exists on Debian and Fedora
* Add pandoc install for MacOS